### PR TITLE
Adds new feature that sums pixel counts by LULC parent category

### DIFF
--- a/src/pixel_counter.py
+++ b/src/pixel_counter.py
@@ -136,26 +136,38 @@ def zonal_stats(vector_path, raster_path, nodata_value=None, global_src_extent=F
             'FID': int(feat.GetFID()),
             'HydroID': feat.GetField('HydroID'),
             'TotalPixels': int(masked.count()),
-            '11': np.count_nonzero((masked == [11])),
-            '12': np.count_nonzero((masked == [12])),
-            '21': np.count_nonzero((masked == [21])),
-            '22': np.count_nonzero((masked == [22])),
-            '23': np.count_nonzero((masked == [23])),
-            '24': np.count_nonzero((masked == [24])),
-            '31': np.count_nonzero((masked == [31])),
-            '41': np.count_nonzero((masked == [41])),
-            '42': np.count_nonzero((masked == [42])),
-            '43': np.count_nonzero((masked == [43])),
-            '51': np.count_nonzero((masked == [51])),
-            '52': np.count_nonzero((masked == [52])),
-            '71': np.count_nonzero((masked == [71])),
-            '72': np.count_nonzero((masked == [72])),
-            '73': np.count_nonzero((masked == [73])),
-            '74': np.count_nonzero((masked == [74])),
-            '81': np.count_nonzero((masked == [81])),
-            '82': np.count_nonzero((masked == [82])),
-            '90': np.count_nonzero((masked == [90])),
-            '95': np.count_nonzero((masked == [95])),
+            'lulc_11': np.count_nonzero((masked == [11])),
+            'lulc_12': np.count_nonzero((masked == [12])),
+            'lulc_21': np.count_nonzero((masked == [21])),
+            'lulc_22': np.count_nonzero((masked == [22])),
+            'lulc_23': np.count_nonzero((masked == [23])),
+            'lulc_24': np.count_nonzero((masked == [24])),
+            'lulc_31': np.count_nonzero((masked == [31])),
+            'lulc_41': np.count_nonzero((masked == [41])),
+            'lulc_42': np.count_nonzero((masked == [42])),
+            'lulc_43': np.count_nonzero((masked == [43])),
+            'lulc_51': np.count_nonzero((masked == [51])),
+            'lulc_52': np.count_nonzero((masked == [52])),
+            'lulc_71': np.count_nonzero((masked == [71])),
+            'lulc_72': np.count_nonzero((masked == [72])),
+            'lulc_73': np.count_nonzero((masked == [73])),
+            'lulc_74': np.count_nonzero((masked == [74])),
+            'lulc_81': np.count_nonzero((masked == [81])),
+            'lulc_82': np.count_nonzero((masked == [82])),
+            'lulc_90': np.count_nonzero((masked == [90])),
+            'lulc_95': np.count_nonzero((masked == [95])),
+            'lulc_1': np.count_nonzero((masked == [11])) + np.count_nonzero((masked == [12])),
+            'lulc_2': np.count_nonzero((masked == [21])) + np.count_nonzero((masked == [22]))
+                      + np.count_nonzero((masked == [23])) + np.count_nonzero((masked == [24])),
+            'lulc_3': np.count_nonzero((masked == [31])),
+            'lulc_4': np.count_nonzero((masked == [41])) + np.count_nonzero((masked == [42]))
+                      + np.count_nonzero((masked == [43])),
+            'lulc_5': np.count_nonzero((masked == [51])) + np.count_nonzero((masked == [52])),
+            'lulc_7': np.count_nonzero((masked == [71])) + np.count_nonzero((masked == [72]))
+                      + np.count_nonzero((masked == [73])) + np.count_nonzero((masked == [74])),
+            'lulc_8': np.count_nonzero((masked == [81])) + np.count_nonzero((masked == [82])),
+            'lulc_9': np.count_nonzero((masked == [90])) + np.count_nonzero((masked == [95]))
+
         }
         stats.append(feature_stats)
 
@@ -170,8 +182,8 @@ def zonal_stats(vector_path, raster_path, nodata_value=None, global_src_extent=F
 
 # Creates and prints dataframe containing desired statistics
 if __name__ == "__main__":
-    #opts = {'VECTOR': sys.argv[1:], 'RASTER': sys.argv[2:]}
-    #stats = zonal_stats(opts['VECTOR'], opts['RASTER'])
+    # opts = {'VECTOR': sys.argv[1:], 'RASTER': sys.argv[2:]}
+    # stats = zonal_stats(opts['VECTOR'], opts['RASTER'])
 
     parser = argparse.ArgumentParser(description='Computes pixel counts for raster classes within a vector area.')
     parser.add_argument('-v', '--vector',
@@ -188,8 +200,7 @@ if __name__ == "__main__":
     vector = args['vector']
     raster = args['raster']
     export = args['csv']
-    stats = zonal_stats(vector,raster)
-
+    stats = zonal_stats(vector, raster)
 
     # Export CSV
     df = pd.DataFrame(stats)


### PR DESCRIPTION
**Script Update**

- The updated script includes a column field that combines child landcover class categories into their parent categories by summing the total number of child category pixels (e.g. NLCD categories 11 and 12 are summed to create an NLCD category 1). 

- Column headings have been updated from the NLCD value to include "lulc_"  as a prefix (e.g. 11 --> lulc_11).

Updates are found on new lines 139 through lines 169:

<img width="776" alt="Screen Shot 2022-03-08 at 7 59 50 AM" src="https://user-images.githubusercontent.com/55287390/157252533-296952bd-768d-4522-b14b-83a4db13f0ee.png">
