### PR TITLE
Adds "LULC" label to output csv column headers

### DIFF
--- a/src/pixel_counter.py
+++ b/src/pixel_counter.py
@@ -2,9 +2,9 @@
 Written by:
 Anuska Narayanan (The University of Alabama Department of Geography, anarayanan1@crimson.ua.edu;
 Sophie Williams (The University of Alabama Department of Geography, scwilliams8@crimson.ua.edu; and
-Brad Bates (NOAA, Lynker, and the National Water Center, bradford.bates@noaa.gov
+Brad Bates (NOAA, Lynker, and the National Water Center, bradford.bates@noaa.gov)
 
-Derived from a Python version of a zonal statistics function writted by Matthew Perry (@perrygeo).
+Derived from a Python version of a zonal statistics function written by Matthew Perry (@perrygeo).
 
 Description: This script isolates the number of pixels per class of a raster within the outlines of
 one or more polygons and displays them in a table. It accomplishes this by rasterizing the vector file,


### PR DESCRIPTION
### Changes
pixel_counter.py :

- Modifies text labels above each column of the output csv file to specify that the number in that column header refers to a category of land use or land cover
- For example, a column header of "11" becomes "LULC_11"
- This makes the output csv easier to interpret, by letting a user know that the LULC classes are listed in each column of the csv

### Testing

- Tested on sample files:
- A sample catchment file "gw_catchments_reaches_filtered_addedAttributes_crosswalked.gpkg" as the vector input
- The national land cover database "nlcd_2019_land_cover_l48_20210604" as the raster input

### Screenshots

- Printed output shows changes to column headers (main output a csv file)
![Screen Shot 2022-03-04 at 15 59 36](https://user-images.githubusercontent.com/98419729/156847771-5933978f-0a5d-4b42-b748-936923a87c0a.png)
