### PR TITLE
Flood Extent Enhancement

### DIFF
--- a/src/pixel_counter.py
+++ b/src/pixel_counter.py
@@ -30,6 +30,7 @@ import argparse
 from pandas import DataFrame
 import copy
 import pathlib
+import tempfile
 
 from pixel_counter_functions import (get_nlcd_counts, get_levee_counts, get_bridge_counts, get_nlcd_counts_inside_flood)
 
@@ -71,7 +72,10 @@ def make_flood_extent_polygon(flood_extent):
     # set up inputs for converting flood extent raster to polygon
     band = target.GetRasterBand(1)
     band.ReadAsArray()
-    outShapefile = "polygonized.shp"
+
+    outshape_location = tempfile.gettempdir()
+    outshape_location_path = os.path.abspath(outshape_location)
+    outShapefile = outshape_location_path + "/" + "polygonized.shp"
     driver = ogr.GetDriverByName("ESRI Shapefile")
     outDatasource = driver.CreateDataSource(outShapefile)
     outLayer = outDatasource.CreateLayer("buffalo", srs=None)

--- a/src/pixel_counter.py
+++ b/src/pixel_counter.py
@@ -23,17 +23,73 @@ from osgeo.gdalconst import *
 import numpy as np
 # Import file management library
 import sys
+import os
 # Import data analysis library
 import pandas as pd
 import argparse
 from pandas import DataFrame
+import copy
+import pathlib
 
-from pixel_counter_functions import (get_nlcd_counts, get_levee_counts, get_bridge_counts)
+from pixel_counter_functions import (get_nlcd_counts, get_levee_counts, get_bridge_counts, get_nlcd_counts_inside_flood)
 
 # Set up error handler
 gdal.PushErrorHandler('CPLQuietErrorHandler')
 
+# Function to pologonize flood extent
+def make_flood_extent_polygon(flood_extent):
+    flood_extent_dataset = gdal.Open(flood_extent)
+    cols = flood_extent_dataset.RasterXSize
+    rows = flood_extent_dataset.RasterYSize
 
+    # Get some metadata to filter out NaN values
+    flood_extent_raster = flood_extent_dataset.GetRasterBand(1)
+    noDataVal = flood_extent_raster.GetNoDataValue()  # no data value
+    scaleFactor = flood_extent_raster.GetScale()  # scale factor
+
+    # Assign flood_extent No Data Values to NaN
+    flood_extent_array = flood_extent_dataset.GetRasterBand(1).ReadAsArray(0, 0, cols, rows).astype(np.float)
+    flood_extent_array[flood_extent_array == int(noDataVal)] = np.nan
+    flood_extent_array = flood_extent_array / scaleFactor
+
+    # Assign flood_extent Negative Values to NaN
+    flood_extent_nonzero_array = copy.copy(flood_extent_array)
+    flood_extent_nonzero_array[flood_extent_array < 0] = np.nan
+
+    # make temporary output file
+    mem_drv = gdal.GetDriverByName('MEM')
+    target = mem_drv.Create('temp_tif', cols, rows, 1, gdal.GDT_Float32)
+    target.GetRasterBand(1).WriteArray(flood_extent_nonzero_array)
+
+    # Add GeoTranform and Projection
+    geotrans = flood_extent_dataset.GetGeoTransform()
+    proj = flood_extent_dataset.GetProjection()
+    target.SetGeoTransform(geotrans)
+    target.SetProjection(proj)
+    target.FlushCache()
+
+    # set up inputs for converting flood extent raster to polygon
+    band = target.GetRasterBand(1)
+    band.ReadAsArray()
+    outShapefile = "polygonized.shp"
+    driver = ogr.GetDriverByName("ESRI Shapefile")
+    outDatasource = driver.CreateDataSource(outShapefile)
+    outLayer = outDatasource.CreateLayer("buffalo", srs=None)
+
+    # Add the DN field
+    newField = ogr.FieldDefn('HydroID', ogr.OFTInteger)
+    outLayer.CreateField(newField)
+
+    # Polygonize
+    gdal.Polygonize(band, None, outLayer, 0, [], callback=None)
+    outDatasource.Destroy()
+    sourceRaster = None
+
+    fullpath = os.path.abspath(outShapefile)
+    print(fullpath)
+    print(type(fullpath))
+
+    return fullpath
 # Function that transforms vector dataset to raster
 def bbox_to_pixel_offsets(gt, bbox):
     originX = gt[0]
@@ -59,8 +115,10 @@ def zonal_stats(vector_path, raster_path_dict, nodata_value=None, global_src_ext
     for layer in raster_path_dict:
         raster_path = raster_path_dict[layer]
         if raster_path == "":  # Only process if a raster path is provided
-            break
-    
+            continue
+        if layer == 'flood_extent' and raster_path_dict["nlcd"]!= "":
+            vector_path = make_flood_extent_polygon(flood_extent)
+            raster_path = raster_path_dict["nlcd"]
         # Opens raster file and sets path
         rds = gdal.Open(raster_path, GA_ReadOnly)
         assert rds
@@ -70,10 +128,12 @@ def zonal_stats(vector_path, raster_path_dict, nodata_value=None, global_src_ext
         if nodata_value:
             nodata_value = float(nodata_value)
             rb.SetNoDataValue(nodata_value)
+        if vector_path == "":
+            print('No vector path provided. Continuing to next layer.')
+            continue
         # Opens vector file and sets path
         vds = ogr.Open(vector_path)
         vlyr = vds.GetLayer(0)
-    
         # Creates an in-memory numpy array of the source raster data covering the whole extent of the vector layer
         if global_src_extent:
             # use global source extent
@@ -149,9 +209,10 @@ def zonal_stats(vector_path, raster_path_dict, nodata_value=None, global_src_ext
                 feature_stats = get_levee_counts(feat, masked)
             if layer == "bridges":
                 feature_stats = get_bridge_counts(feat, masked)
-            
+            if layer == "flood_extent":
+                feature_stats = get_nlcd_counts_inside_flood(feat, masked)
+
             stats.append(feature_stats)
-    
             rvds = None
             mem_ds = None
             feat = vlyr.GetNextFeature()
@@ -169,7 +230,8 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Computes pixel counts for raster classes within a vector area.')
     parser.add_argument('-v', '--vector',
                         help='Path to vector file.',
-                        required=True)
+                        required=False,
+                        default="")
     parser.add_argument('-n', '--nlcd',
                         help='Path to National Land Cover Database raster file.',
                         required=False,
@@ -182,6 +244,10 @@ if __name__ == "__main__":
                         help='Path to bridges file.',
                         required=False,
                         default="")
+    parser.add_argument('-f', '--flood_extent',
+                        help='Path to flood extent file.',
+                        required=False,
+                        default="")
     parser.add_argument('-c', '--csv',
                         help='Path to export csv file.',
                         required=True)
@@ -191,13 +257,16 @@ if __name__ == "__main__":
     nlcd = args['nlcd']
     levees = args['levees']
     bridges = args['bridges']
+    flood_extent = args['flood_extent']
 
     csv = args['csv']
 
-    raster_path_dict = {'nlcd': nlcd, 'levees': levees, 'bridges': bridges}
+    raster_path_dict = {'nlcd': nlcd, 'levees': levees, 'bridges': bridges, 'flood_extent': flood_extent}
     
     stats = zonal_stats(vector, raster_path_dict)
 
     # Export CSV
     df = pd.DataFrame(stats)
-    df.to_csv(csv, index=False)
+    result = df[(df >= 0).all(axis=1)]
+    df2 = pd.DataFrame(result)
+    df2.to_csv(csv, index=False)

--- a/src/pixel_counter_functions.py
+++ b/src/pixel_counter_functions.py
@@ -1,5 +1,44 @@
 import numpy as np
-        
+def get_nlcd_counts_inside_flood(feat,masked):
+    # Gets NLCD Counds inside flood extent
+    feature_stats = {
+        'f_HydroID': feat.GetField('HydroID'),
+        'f_TotalPixels': int(masked.count()),
+        'f_lulc_11': np.count_nonzero((masked == [11])),
+        'f_lulc_12': np.count_nonzero((masked == [12])),
+        'f_lulc_21': np.count_nonzero((masked == [21])),
+        'f_lulc_22': np.count_nonzero((masked == [22])),
+        'f_lulc_23': np.count_nonzero((masked == [23])),
+        'f_lulc_24': np.count_nonzero((masked == [24])),
+        'f_lulc_31': np.count_nonzero((masked == [31])),
+        'f_lulc_41': np.count_nonzero((masked == [41])),
+        'f_lulc_42': np.count_nonzero((masked == [42])),
+        'f_lulc_43': np.count_nonzero((masked == [43])),
+        'f_lulc_51': np.count_nonzero((masked == [51])),
+        'f_lulc_52': np.count_nonzero((masked == [52])),
+        'f_lulc_71': np.count_nonzero((masked == [71])),
+        'f_lulc_72': np.count_nonzero((masked == [72])),
+        'f_lulc_73': np.count_nonzero((masked == [73])),
+        'f_lulc_74': np.count_nonzero((masked == [74])),
+        'f_lulc_81': np.count_nonzero((masked == [81])),
+        'f_lulc_82': np.count_nonzero((masked == [82])),
+        'f_lulc_90': np.count_nonzero((masked == [90])),
+        'f_lulc_95': np.count_nonzero((masked == [95])),
+        'f_lulc_1': np.count_nonzero((masked == [11])) + np.count_nonzero((masked == [12])),
+        'f_lulc_2': np.count_nonzero((masked == [21])) + np.count_nonzero((masked == [22]))
+                  + np.count_nonzero((masked == [23])) + np.count_nonzero((masked == [24])),
+        'f_lulc_3': np.count_nonzero((masked == [31])),
+        'f_lulc_4': np.count_nonzero((masked == [41])) + np.count_nonzero((masked == [42]))
+                  + np.count_nonzero((masked == [43])),
+        'f_lulc_5': np.count_nonzero((masked == [51])) + np.count_nonzero((masked == [52])),
+        'f_lulc_7': np.count_nonzero((masked == [71])) + np.count_nonzero((masked == [72]))
+                  + np.count_nonzero((masked == [73])) + np.count_nonzero((masked == [74])),
+        'f_lulc_8': np.count_nonzero((masked == [81])) + np.count_nonzero((masked == [82])),
+        'f_lulc_9': np.count_nonzero((masked == [90])) + np.count_nonzero((masked == [95]))
+
+    }
+    return feature_stats
+
 
 def get_nlcd_counts(feat, masked):
     # Acquires information for table on each raster attribute per poly feature


### PR DESCRIPTION
**Changes**

Two changes were made to pixel_counter.py and pixel_counter_functions.py:

Within pixel_counter.py, a new function was added: make_flood_extent_polygon.

- This function converts the input inundation extent raster to a polygon 
- The output file is then fed into the main pixel counter function.

Within pixel_counter_functions.py, the method of counting and output column headers were modified.

- Only the NLCD pixel counts of inundated regions are returned in the output .csv file
- Columns are renamed  "_f_NLCDValue_" to avoid confusion with the pixel counts for the total catchment. 

**Input Requirements**:
- Inundation Extent in .tif format with inundated regions given positive HydroIDs and non inundated areas given negative HydroIDs
- Rasterized NLCD Layer 

Output: CSV file displaying the number of NLCD pixels per catchment within the flood extent

**Testing**
Tested on sample files:

A sample inundation extent  100_0_ms_inund_extent_12090301.tif
A national NLCD dataset: nlcd_2019_land_cover_l48_20210604.img 

The output CSV file shows NLCD pixels within the inputed flooded boundaries categorized by land cover type grouped by catchment HydroID
[myCSV22.csv](https://github.com/BradfordBates-NOAA/catchment-enricher/files/8473026/myCSV22.csv)